### PR TITLE
Redis: Update to 8.0.4

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -6,28 +6,28 @@ Maintainers: Adam Ben Shmuel <adam.ben-shmuel@redis.com> (@adamiBs),
              Petar Shtuchkin <petar.shtuchkin@redis.com> (@Peter-Sh)
 GitRepo: https://github.com/redis/docker-library-redis.git
 
-Tags: 8.2.1, 8.2, 8, 8.2.1-bookworm, 8.2-bookworm, 8-bookworm, latest, bookworm
+Tags: 8.2.2, 8.2, 8, 8.2.2-bookworm, 8.2-bookworm, 8-bookworm, latest, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a13b78815d980881e57f15b9cf13cd2f26f3fab6
-GitFetch: refs/heads/release/8.2
+GitCommit: f76d8a1cc979be6202aed93efddd2a0ebbfa0209
+GitFetch: refs/tags/v8.2.2
 Directory: debian
 
-Tags: 8.2.1-alpine, 8.2-alpine, 8-alpine, 8.2.1-alpine3.22, 8.2-alpine3.22, 8-alpine3.22, alpine, alpine3.22
+Tags: 8.2.2-alpine, 8.2-alpine, 8-alpine, 8.2.2-alpine3.22, 8.2-alpine3.22, 8-alpine3.22, alpine, alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a13b78815d980881e57f15b9cf13cd2f26f3fab6
-GitFetch: refs/heads/release/8.2
+GitCommit: f76d8a1cc979be6202aed93efddd2a0ebbfa0209
+GitFetch: refs/tags/v8.2.2
 Directory: alpine
 
-Tags: 8.0.3, 8.0, 8.0.3-bookworm, 8.0-bookworm
+Tags: 8.0.4, 8.0, 8.0.4-bookworm, 8.0-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 101262a8cf05b98137d88bc17e77db90c24cc783
-GitFetch: refs/heads/release/8.0
+GitCommit: c0125f5be8786d556a9d3edd70f51974fe045c1a
+GitFetch: refs/tags/v8.0.4
 Directory: debian
 
-Tags: 8.0.3-alpine, 8.0-alpine, 8.0.3-alpine3.21, 8.0-alpine3.21
+Tags: 8.0.4-alpine, 8.0-alpine, 8.0.4-alpine3.21, 8.0-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 101262a8cf05b98137d88bc17e77db90c24cc783
-GitFetch: refs/heads/release/8.0
+GitCommit: c0125f5be8786d556a9d3edd70f51974fe045c1a
+GitFetch: refs/tags/v8.0.4
 Directory: alpine
 
 Tags: 7.4.5, 7.4, 7, 7.4.5-bookworm, 7.4-bookworm, 7-bookworm


### PR DESCRIPTION
Automated update for Redis 8.0.4

Release commit: 2277e5ead99f0caacbd90e0d04693adb27ebfaa6
Release tag: v8.0.4
Compare: https://github.com/redis/docker-library-redis/compare/v8.0.4^1...v8.0.4

@adamiBs @yossigo @adobrzhansky @maxb-io @dagansandler @Peter-Sh