### PR TITLE
Redis: Update to 8.0.5

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -8,26 +8,26 @@ GitRepo: https://github.com/redis/docker-library-redis.git
 
 Tags: 8.2.2, 8.2, 8, 8.2.2-bookworm, 8.2-bookworm, 8-bookworm, latest, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c5846c13383c8b284897ff171e0c946868ed4c8c
+GitCommit: f76d8a1cc979be6202aed93efddd2a0ebbfa0209
 GitFetch: refs/tags/v8.2.2
 Directory: debian
 
 Tags: 8.2.2-alpine, 8.2-alpine, 8-alpine, 8.2.2-alpine3.22, 8.2-alpine3.22, 8-alpine3.22, alpine, alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c5846c13383c8b284897ff171e0c946868ed4c8c
+GitCommit: f76d8a1cc979be6202aed93efddd2a0ebbfa0209
 GitFetch: refs/tags/v8.2.2
 Directory: alpine
 
-Tags: 8.0.4, 8.0, 8.0.4-bookworm, 8.0-bookworm
+Tags: 8.0.5, 8.0, 8.0.5-bookworm, 8.0-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2277e5ead99f0caacbd90e0d04693adb27ebfaa6
-GitFetch: refs/tags/v8.0.4
+GitCommit: c8a3cc8bf081db74a252c6423c932437682058a9
+GitFetch: refs/tags/v8.0.5
 Directory: debian
 
-Tags: 8.0.4-alpine, 8.0-alpine, 8.0.4-alpine3.21, 8.0-alpine3.21
+Tags: 8.0.5-alpine, 8.0-alpine, 8.0.5-alpine3.21, 8.0-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2277e5ead99f0caacbd90e0d04693adb27ebfaa6
-GitFetch: refs/tags/v8.0.4
+GitCommit: c8a3cc8bf081db74a252c6423c932437682058a9
+GitFetch: refs/tags/v8.0.5
 Directory: alpine
 
 Tags: 7.4.7, 7.4, 7, 7.4.7-bookworm, 7.4-bookworm, 7-bookworm


### PR DESCRIPTION
Automated update for Redis 8.0.5

Release commit: 32adf916e545602f05e0bf031e789ab72012cf38
Release tag: v8.0.5
Compare: https://github.com/redis/docker-library-redis/compare/v8.0.5^1...v8.0.5

@adamiBs @yossigo @adobrzhansky @maxb-io @dagansandler @Peter-Sh