### PR TITLE
Redis: Update to 8.2.3

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -6,16 +6,16 @@ Maintainers: Adam Ben Shmuel <adam.ben-shmuel@redis.com> (@adamiBs),
              Petar Shtuchkin <petar.shtuchkin@redis.com> (@Peter-Sh)
 GitRepo: https://github.com/redis/docker-library-redis.git
 
-Tags: 8.2.2, 8.2, 8, 8.2.2-bookworm, 8.2-bookworm, 8-bookworm, latest, bookworm
+Tags: 8.2.3, 8.2, 8, 8.2.3-bookworm, 8.2-bookworm, 8-bookworm, latest, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f76d8a1cc979be6202aed93efddd2a0ebbfa0209
-GitFetch: refs/tags/v8.2.2
+GitCommit: 38f0699ba29e25365993fb24861524b2dcc5eb1a
+GitFetch: refs/tags/v8.2.3
 Directory: debian
 
-Tags: 8.2.2-alpine, 8.2-alpine, 8-alpine, 8.2.2-alpine3.22, 8.2-alpine3.22, 8-alpine3.22, alpine, alpine3.22
+Tags: 8.2.3-alpine, 8.2-alpine, 8-alpine, 8.2.3-alpine3.22, 8.2-alpine3.22, 8-alpine3.22, alpine, alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f76d8a1cc979be6202aed93efddd2a0ebbfa0209
-GitFetch: refs/tags/v8.2.2
+GitCommit: 38f0699ba29e25365993fb24861524b2dcc5eb1a
+GitFetch: refs/tags/v8.2.3
 Directory: alpine
 
 Tags: 8.0.5, 8.0, 8.0.5-bookworm, 8.0-bookworm


### PR DESCRIPTION
Automated update for Redis 8.2.3

Release commit: bcbc692165ce2241e194035041c5b5e01d2e1a5f
Release tag: v8.2.3
Compare: https://github.com/redis/docker-library-redis/compare/v8.2.3^1...v8.2.3

@adamiBs @yossigo @adobrzhansky @maxb-io @dagansandler @Peter-Sh