### PR TITLE
Redis: Update to 8.4-rc1

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -6,6 +6,18 @@ Maintainers: Adam Ben Shmuel <adam.ben-shmuel@redis.com> (@adamiBs),
              Petar Shtuchkin <petar.shtuchkin@redis.com> (@Peter-Sh)
 GitRepo: https://github.com/redis/docker-library-redis.git
 
+Tags: 8.4-rc1, 8.4-rc1-bookworm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 47386b7d1129abbe0f2ccc745903da1613977c79
+GitFetch: refs/tags/v8.4-rc1
+Directory: debian
+
+Tags: 8.4-rc1-alpine, 8.4-rc1-alpine3.22
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 47386b7d1129abbe0f2ccc745903da1613977c79
+GitFetch: refs/tags/v8.4-rc1
+Directory: alpine
+
 Tags: 8.2.3, 8.2, 8, 8.2.3-bookworm, 8.2-bookworm, 8-bookworm, latest, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: bcbc692165ce2241e194035041c5b5e01d2e1a5f

--- a/library/redis
+++ b/library/redis
@@ -8,13 +8,13 @@ GitRepo: https://github.com/redis/docker-library-redis.git
 
 Tags: 8.2.3, 8.2, 8, 8.2.3-bookworm, 8.2-bookworm, 8-bookworm, latest, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 38f0699ba29e25365993fb24861524b2dcc5eb1a
+GitCommit: bcbc692165ce2241e194035041c5b5e01d2e1a5f
 GitFetch: refs/tags/v8.2.3
 Directory: debian
 
 Tags: 8.2.3-alpine, 8.2-alpine, 8-alpine, 8.2.3-alpine3.22, 8.2-alpine3.22, 8-alpine3.22, alpine, alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 38f0699ba29e25365993fb24861524b2dcc5eb1a
+GitCommit: bcbc692165ce2241e194035041c5b5e01d2e1a5f
 GitFetch: refs/tags/v8.2.3
 Directory: alpine
 

--- a/library/redis
+++ b/library/redis
@@ -6,16 +6,16 @@ Maintainers: Adam Ben Shmuel <adam.ben-shmuel@redis.com> (@adamiBs),
              Petar Shtuchkin <petar.shtuchkin@redis.com> (@Peter-Sh)
 GitRepo: https://github.com/redis/docker-library-redis.git
 
-Tags: 8.2.2, 8.2, 8, 8.2.2-bookworm, 8.2-bookworm, 8-bookworm, latest, bookworm
+Tags: 8.2.3, 8.2, 8, 8.2.3-bookworm, 8.2-bookworm, 8-bookworm, latest, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f76d8a1cc979be6202aed93efddd2a0ebbfa0209
-GitFetch: refs/tags/v8.2.2
+GitCommit: 38f0699ba29e25365993fb24861524b2dcc5eb1a
+GitFetch: refs/tags/v8.2.3
 Directory: debian
 
-Tags: 8.2.2-alpine, 8.2-alpine, 8-alpine, 8.2.2-alpine3.22, 8.2-alpine3.22, 8-alpine3.22, alpine, alpine3.22
+Tags: 8.2.3-alpine, 8.2-alpine, 8-alpine, 8.2.3-alpine3.22, 8.2-alpine3.22, 8-alpine3.22, alpine, alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f76d8a1cc979be6202aed93efddd2a0ebbfa0209
-GitFetch: refs/tags/v8.2.2
+GitCommit: 38f0699ba29e25365993fb24861524b2dcc5eb1a
+GitFetch: refs/tags/v8.2.3
 Directory: alpine
 
 Tags: 8.0.5, 8.0, 8.0.5-bookworm, 8.0-bookworm

--- a/library/redis
+++ b/library/redis
@@ -8,26 +8,26 @@ GitRepo: https://github.com/redis/docker-library-redis.git
 
 Tags: 8.2.2, 8.2, 8, 8.2.2-bookworm, 8.2-bookworm, 8-bookworm, latest, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c5846c13383c8b284897ff171e0c946868ed4c8c
+GitCommit: f76d8a1cc979be6202aed93efddd2a0ebbfa0209
 GitFetch: refs/tags/v8.2.2
 Directory: debian
 
 Tags: 8.2.2-alpine, 8.2-alpine, 8-alpine, 8.2.2-alpine3.22, 8.2-alpine3.22, 8-alpine3.22, alpine, alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c5846c13383c8b284897ff171e0c946868ed4c8c
+GitCommit: f76d8a1cc979be6202aed93efddd2a0ebbfa0209
 GitFetch: refs/tags/v8.2.2
 Directory: alpine
 
-Tags: 8.0.4, 8.0, 8.0.4-bookworm, 8.0-bookworm
+Tags: 8.0.5, 8.0, 8.0.5-bookworm, 8.0-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2277e5ead99f0caacbd90e0d04693adb27ebfaa6
-GitFetch: refs/tags/v8.0.4
+GitCommit: c8a3cc8bf081db74a252c6423c932437682058a9
+GitFetch: refs/tags/v8.0.5
 Directory: debian
 
-Tags: 8.0.4-alpine, 8.0-alpine, 8.0.4-alpine3.21, 8.0-alpine3.21
+Tags: 8.0.5-alpine, 8.0-alpine, 8.0.5-alpine3.21, 8.0-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2277e5ead99f0caacbd90e0d04693adb27ebfaa6
-GitFetch: refs/tags/v8.0.4
+GitCommit: c8a3cc8bf081db74a252c6423c932437682058a9
+GitFetch: refs/tags/v8.0.5
 Directory: alpine
 
 Tags: 7.4.7, 7.4, 7, 7.4.7-bookworm, 7.4-bookworm, 7-bookworm

--- a/library/redis
+++ b/library/redis
@@ -20,13 +20,13 @@ Directory: alpine
 
 Tags: 8.0.5, 8.0, 8.0.5-bookworm, 8.0-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c8a3cc8bf081db74a252c6423c932437682058a9
+GitCommit: 32adf916e545602f05e0bf031e789ab72012cf38
 GitFetch: refs/tags/v8.0.5
 Directory: debian
 
 Tags: 8.0.5-alpine, 8.0-alpine, 8.0.5-alpine3.21, 8.0-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c8a3cc8bf081db74a252c6423c932437682058a9
+GitCommit: 32adf916e545602f05e0bf031e789ab72012cf38
 GitFetch: refs/tags/v8.0.5
 Directory: alpine
 

--- a/library/redis
+++ b/library/redis
@@ -30,32 +30,32 @@ GitCommit: 2277e5ead99f0caacbd90e0d04693adb27ebfaa6
 GitFetch: refs/tags/v8.0.4
 Directory: alpine
 
-Tags: 7.4.6, 7.4, 7, 7.4.6-bookworm, 7.4-bookworm, 7-bookworm
+Tags: 7.4.7, 7.4, 7, 7.4.7-bookworm, 7.4-bookworm, 7-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7d9ee3a9c8e9b5085cf0e354100a5aaf9be6a744
+GitCommit: d42d7aec93b1c54dd46f37a66a92f62478456039
 Directory: 7.4/debian
 
-Tags: 7.4.6-alpine, 7.4-alpine, 7-alpine, 7.4.6-alpine3.21, 7.4-alpine3.21, 7-alpine3.21
+Tags: 7.4.7-alpine, 7.4-alpine, 7-alpine, 7.4.7-alpine3.21, 7.4-alpine3.21, 7-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 7d9ee3a9c8e9b5085cf0e354100a5aaf9be6a744
+GitCommit: d42d7aec93b1c54dd46f37a66a92f62478456039
 Directory: 7.4/alpine
 
-Tags: 7.2.11, 7.2, 7.2.11-bookworm, 7.2-bookworm
+Tags: 7.2.12, 7.2, 7.2.12-bookworm, 7.2-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7d9ee3a9c8e9b5085cf0e354100a5aaf9be6a744
+GitCommit: d42d7aec93b1c54dd46f37a66a92f62478456039
 Directory: 7.2/debian
 
-Tags: 7.2.11-alpine, 7.2-alpine, 7.2.11-alpine3.21, 7.2-alpine3.21
+Tags: 7.2.12-alpine, 7.2-alpine, 7.2.12-alpine3.21, 7.2-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 7d9ee3a9c8e9b5085cf0e354100a5aaf9be6a744
+GitCommit: d42d7aec93b1c54dd46f37a66a92f62478456039
 Directory: 7.2/alpine
 
-Tags: 6.2.20, 6.2, 6, 6.2.20-bookworm, 6.2-bookworm, 6-bookworm
+Tags: 6.2.21, 6.2, 6, 6.2.21-bookworm, 6.2-bookworm, 6-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7d9ee3a9c8e9b5085cf0e354100a5aaf9be6a744
+GitCommit: d42d7aec93b1c54dd46f37a66a92f62478456039
 Directory: 6.2/debian
 
-Tags: 6.2.20-alpine, 6.2-alpine, 6-alpine, 6.2.20-alpine3.21, 6.2-alpine3.21, 6-alpine3.21
+Tags: 6.2.21-alpine, 6.2-alpine, 6-alpine, 6.2.21-alpine3.21, 6.2-alpine3.21, 6-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 7d9ee3a9c8e9b5085cf0e354100a5aaf9be6a744
+GitCommit: d42d7aec93b1c54dd46f37a66a92f62478456039
 Directory: 6.2/alpine


### PR DESCRIPTION
Automated update for Redis 8.4-rc1

Release commit: 47386b7d1129abbe0f2ccc745903da1613977c79
Release tag: v8.4-rc1
Compare: https://github.com/redis/docker-library-redis/compare/v8.4-rc1^1...v8.4-rc1

@adamiBs @yossigo @adobrzhansky @maxb-io @dagansandler @Peter-Sh