### PR TITLE
Redis: Update to 8.6-rc1

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -6,6 +6,18 @@ Maintainers: Adam Ben Shmuel <adam.ben-shmuel@redis.com> (@adamiBs),
              Petar Shtuchkin <petar.shtuchkin@redis.com> (@Peter-Sh)
 GitRepo: https://github.com/redis/docker-library-redis.git
 
+Tags: 8.6-rc1, 8.6-rc1-trixie
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
+GitCommit: 275b71068b3065fcf794d08f908b61548f451795
+GitFetch: refs/tags/v8.6-rc1
+Directory: debian
+
+Tags: 8.6-rc1-alpine, 8.6-rc1-alpine3.23
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 275b71068b3065fcf794d08f908b61548f451795
+GitFetch: refs/tags/v8.6-rc1
+Directory: alpine
+
 Tags: 8.4.0, 8.4, 8, 8.4.0-bookworm, 8.4-bookworm, 8-bookworm, latest, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: de8bb5f3e3ead8584e76834816b9e7e332d2bd49


### PR DESCRIPTION
Automated update for Redis 8.6-rc1

Release commit: 275b71068b3065fcf794d08f908b61548f451795
Release tag: v8.6-rc1
Compare: https://github.com/redis/docker-library-redis/compare/v8.6-rc1^1...v8.6-rc1

@adamiBs @yossigo @adobrzhansky @maxb-io @dagansandler @Peter-Sh