### PR TITLE
Redis: Update to 8.4.1

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -18,16 +18,16 @@ GitCommit: 275b71068b3065fcf794d08f908b61548f451795
 GitFetch: refs/tags/v8.6-rc1
 Directory: alpine
 
-Tags: 8.4.0, 8.4, 8, 8.4.0-bookworm, 8.4-bookworm, 8-bookworm, latest, bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: de8bb5f3e3ead8584e76834816b9e7e332d2bd49
-GitFetch: refs/tags/v8.4.0
+Tags: 8.4.1, 8.4, 8, 8.4.1-trixie, 8.4-trixie, 8-trixie, latest, trixie
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
+GitCommit: c5effbcb7f9a63ece6e9ca0d20de488f11c2df68
+GitFetch: refs/tags/v8.4.1
 Directory: debian
 
-Tags: 8.4.0-alpine, 8.4-alpine, 8-alpine, 8.4.0-alpine3.22, 8.4-alpine3.22, 8-alpine3.22, alpine, alpine3.22
+Tags: 8.4.1-alpine, 8.4-alpine, 8-alpine, 8.4.1-alpine3.22, 8.4-alpine3.22, 8-alpine3.22, alpine, alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: de8bb5f3e3ead8584e76834816b9e7e332d2bd49
-GitFetch: refs/tags/v8.4.0
+GitCommit: c5effbcb7f9a63ece6e9ca0d20de488f11c2df68
+GitFetch: refs/tags/v8.4.1
 Directory: alpine
 
 Tags: 8.2.3, 8.2, 8.2.3-bookworm, 8.2-bookworm


### PR DESCRIPTION
Automated update for Redis 8.4.1

Release commit: c5effbcb7f9a63ece6e9ca0d20de488f11c2df68
Release tag: v8.4.1
Compare: https://github.com/redis/docker-library-redis/compare/v8.4.1^1...v8.4.1

@adamiBs @yossigo @adobrzhansky @maxb-io @dagansandler @Peter-Sh