### PR TITLE
Redis: Update to 8.6.0

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -6,28 +6,28 @@ Maintainers: Adam Ben Shmuel <adam.ben-shmuel@redis.com> (@adamiBs),
              Petar Shtuchkin <petar.shtuchkin@redis.com> (@Peter-Sh)
 GitRepo: https://github.com/redis/docker-library-redis.git
 
-Tags: 8.6-rc1, 8.6-rc1-trixie
+Tags: 8.6.0, 8.6, 8, 8.6.0-trixie, 8.6-trixie, 8-trixie, latest, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
-GitCommit: 275b71068b3065fcf794d08f908b61548f451795
-GitFetch: refs/tags/v8.6-rc1
+GitCommit: 980a73fbe9c6b7be0c251ff453c8ffdbef6700fc
+GitFetch: refs/tags/v8.6.0
 Directory: debian
 
-Tags: 8.6-rc1-alpine, 8.6-rc1-alpine3.23
+Tags: 8.6.0-alpine, 8.6-alpine, 8-alpine, 8.6.0-alpine3.23, 8.6-alpine3.23, 8-alpine3.23, alpine, alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 275b71068b3065fcf794d08f908b61548f451795
-GitFetch: refs/tags/v8.6-rc1
+GitCommit: 980a73fbe9c6b7be0c251ff453c8ffdbef6700fc
+GitFetch: refs/tags/v8.6.0
 Directory: alpine
 
-Tags: 8.4.0, 8.4, 8, 8.4.0-bookworm, 8.4-bookworm, 8-bookworm, latest, bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: de8bb5f3e3ead8584e76834816b9e7e332d2bd49
-GitFetch: refs/tags/v8.4.0
+Tags: 8.4.1, 8.4, 8.4.1-trixie, 8.4-trixie
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
+GitCommit: c5effbcb7f9a63ece6e9ca0d20de488f11c2df68
+GitFetch: refs/tags/v8.4.1
 Directory: debian
 
-Tags: 8.4.0-alpine, 8.4-alpine, 8-alpine, 8.4.0-alpine3.22, 8.4-alpine3.22, 8-alpine3.22, alpine, alpine3.22
+Tags: 8.4.1-alpine, 8.4-alpine, 8.4.1-alpine3.22, 8.4-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: de8bb5f3e3ead8584e76834816b9e7e332d2bd49
-GitFetch: refs/tags/v8.4.0
+GitCommit: c5effbcb7f9a63ece6e9ca0d20de488f11c2df68
+GitFetch: refs/tags/v8.4.1
 Directory: alpine
 
 Tags: 8.2.3, 8.2, 8.2.3-bookworm, 8.2-bookworm


### PR DESCRIPTION
Automated update for Redis 8.6.0

Release commit: 980a73fbe9c6b7be0c251ff453c8ffdbef6700fc
Release tag: v8.6.0
Compare: https://github.com/redis/docker-library-redis/compare/v8.6.0^1...v8.6.0

@adamiBs @yossigo @adobrzhansky @maxb-io @dagansandler @Peter-Sh