### PR TITLE
Redis: Update to 8.2.4

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -30,16 +30,16 @@ GitCommit: c5effbcb7f9a63ece6e9ca0d20de488f11c2df68
 GitFetch: refs/tags/v8.4.1
 Directory: alpine
 
-Tags: 8.2.3, 8.2, 8.2.3-bookworm, 8.2-bookworm
+Tags: 8.2.4, 8.2, 8.2.4-bookworm, 8.2-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: bcbc692165ce2241e194035041c5b5e01d2e1a5f
-GitFetch: refs/tags/v8.2.3
+GitCommit: 6dabc615e3296bea231564400fa89e4b8b1312ee
+GitFetch: refs/tags/v8.2.4
 Directory: debian
 
-Tags: 8.2.3-alpine, 8.2-alpine, 8.2.3-alpine3.22, 8.2-alpine3.22
+Tags: 8.2.4-alpine, 8.2-alpine, 8.2.4-alpine3.22, 8.2-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: bcbc692165ce2241e194035041c5b5e01d2e1a5f
-GitFetch: refs/tags/v8.2.3
+GitCommit: 6dabc615e3296bea231564400fa89e4b8b1312ee
+GitFetch: refs/tags/v8.2.4
 Directory: alpine
 
 Tags: 8.0.5, 8.0, 8.0.5-bookworm, 8.0-bookworm


### PR DESCRIPTION
Automated update for Redis 8.2.4

Release commit: 6dabc615e3296bea231564400fa89e4b8b1312ee
Release tag: v8.2.4
Compare: https://github.com/redis/docker-library-redis/compare/v8.2.4^1...v8.2.4

@adamiBs @yossigo @adobrzhansky @maxb-io @dagansandler @Peter-Sh