### PR TITLE
Redis: Update to 8.0.6

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -42,16 +42,16 @@ GitCommit: 6dabc615e3296bea231564400fa89e4b8b1312ee
 GitFetch: refs/tags/v8.2.4
 Directory: alpine
 
-Tags: 8.0.5, 8.0, 8.0.5-bookworm, 8.0-bookworm
+Tags: 8.0.6, 8.0, 8.0.6-bookworm, 8.0-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 32adf916e545602f05e0bf031e789ab72012cf38
-GitFetch: refs/tags/v8.0.5
+GitCommit: 7f2385183921bba168de2f0444cf455637c044e3
+GitFetch: refs/tags/v8.0.6
 Directory: debian
 
-Tags: 8.0.5-alpine, 8.0-alpine, 8.0.5-alpine3.21, 8.0-alpine3.21
+Tags: 8.0.6-alpine, 8.0-alpine, 8.0.6-alpine3.21, 8.0-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 32adf916e545602f05e0bf031e789ab72012cf38
-GitFetch: refs/tags/v8.0.5
+GitCommit: 7f2385183921bba168de2f0444cf455637c044e3
+GitFetch: refs/tags/v8.0.6
 Directory: alpine
 
 Tags: 7.4.7, 7.4, 7, 7.4.7-bookworm, 7.4-bookworm, 7-bookworm


### PR DESCRIPTION
Automated update for Redis 8.0.6

Release commit: 7f2385183921bba168de2f0444cf455637c044e3
Release tag: v8.0.6
Compare: https://github.com/redis/docker-library-redis/compare/v8.0.6^1...v8.0.6

@adamiBs @yossigo @adobrzhansky @maxb-io @dagansandler @Peter-Sh