### PR TITLE
Redis: Update to 8.4.2

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -6,28 +6,28 @@ Maintainers: Adam Ben Shmuel <adam.ben-shmuel@redis.com> (@adamiBs),
              Petar Shtuchkin <petar.shtuchkin@redis.com> (@Peter-Sh)
 GitRepo: https://github.com/redis/docker-library-redis.git
 
-Tags: 8.6.0, 8.6, 8, 8.6.0-trixie, 8.6-trixie, 8-trixie, latest, trixie
+Tags: 8.6.1, 8.6, 8, 8.6.1-trixie, 8.6-trixie, 8-trixie, latest, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
-GitCommit: 980a73fbe9c6b7be0c251ff453c8ffdbef6700fc
-GitFetch: refs/tags/v8.6.0
+GitCommit: 772020f24a0acb30ffaa6647f3c79a7f3932225d
+GitFetch: refs/tags/v8.6.1
 Directory: debian
 
-Tags: 8.6.0-alpine, 8.6-alpine, 8-alpine, 8.6.0-alpine3.23, 8.6-alpine3.23, 8-alpine3.23, alpine, alpine3.23
+Tags: 8.6.1-alpine, 8.6-alpine, 8-alpine, 8.6.1-alpine3.23, 8.6-alpine3.23, 8-alpine3.23, alpine, alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 980a73fbe9c6b7be0c251ff453c8ffdbef6700fc
-GitFetch: refs/tags/v8.6.0
+GitCommit: 772020f24a0acb30ffaa6647f3c79a7f3932225d
+GitFetch: refs/tags/v8.6.1
 Directory: alpine
 
-Tags: 8.4.1, 8.4, 8.4.1-trixie, 8.4-trixie
+Tags: 8.4.2, 8.4, 8.4.2-trixie, 8.4-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
-GitCommit: c5effbcb7f9a63ece6e9ca0d20de488f11c2df68
-GitFetch: refs/tags/v8.4.1
+GitCommit: f57c53203ef603901bd75cbee76f1f5a5d56d8fa
+GitFetch: refs/tags/v8.4.2
 Directory: debian
 
-Tags: 8.4.1-alpine, 8.4-alpine, 8.4.1-alpine3.22, 8.4-alpine3.22
+Tags: 8.4.2-alpine, 8.4-alpine, 8.4.2-alpine3.22, 8.4-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c5effbcb7f9a63ece6e9ca0d20de488f11c2df68
-GitFetch: refs/tags/v8.4.1
+GitCommit: f57c53203ef603901bd75cbee76f1f5a5d56d8fa
+GitFetch: refs/tags/v8.4.2
 Directory: alpine
 
 Tags: 8.2.4, 8.2, 8.2.4-bookworm, 8.2-bookworm
@@ -42,16 +42,16 @@ GitCommit: 6dabc615e3296bea231564400fa89e4b8b1312ee
 GitFetch: refs/tags/v8.2.4
 Directory: alpine
 
-Tags: 8.0.5, 8.0, 8.0.5-bookworm, 8.0-bookworm
+Tags: 8.0.6, 8.0, 8.0.6-bookworm, 8.0-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 32adf916e545602f05e0bf031e789ab72012cf38
-GitFetch: refs/tags/v8.0.5
+GitCommit: 7f2385183921bba168de2f0444cf455637c044e3
+GitFetch: refs/tags/v8.0.6
 Directory: debian
 
-Tags: 8.0.5-alpine, 8.0-alpine, 8.0.5-alpine3.21, 8.0-alpine3.21
+Tags: 8.0.6-alpine, 8.0-alpine, 8.0.6-alpine3.21, 8.0-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 32adf916e545602f05e0bf031e789ab72012cf38
-GitFetch: refs/tags/v8.0.5
+GitCommit: 7f2385183921bba168de2f0444cf455637c044e3
+GitFetch: refs/tags/v8.0.6
 Directory: alpine
 
 Tags: 7.4.7, 7.4, 7, 7.4.7-bookworm, 7.4-bookworm, 7-bookworm


### PR DESCRIPTION
Automated update for Redis 8.4.2

Release commit: f57c53203ef603901bd75cbee76f1f5a5d56d8fa
Release tag: v8.4.2
Compare: https://github.com/redis/docker-library-redis/compare/v8.4.2^1...v8.4.2

@adamiBs @yossigo @adobrzhansky @maxb-io @dagansandler @Peter-Sh