### PR TITLE
Redis: Update to 7.4.8

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -54,25 +54,17 @@ GitCommit: 7f2385183921bba168de2f0444cf455637c044e3
 GitFetch: refs/tags/v8.0.6
 Directory: alpine
 
-Tags: 7.4.8, 7.4, 7, 7.4.8-bookworm, 7.4-bookworm, 7-bookworm
+Tags: 7.4.8, 7.4, 7, 7.4.8-bookworm, 7.4-bookworm, 7-bookworm, latest, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9d9b74b729d555ef784db63c1941b73d1c47a6f9
-Directory: 7.4/debian
+GitCommit: 0e6db74e25f6b4e301b4e9a1fb3e72443a8ba4d7
+GitFetch: refs/tags/v7.4.8
+Directory: debian
 
-Tags: 7.4.8-alpine, 7.4-alpine, 7-alpine, 7.4.8-alpine3.21, 7.4-alpine3.21, 7-alpine3.21
+Tags: 7.4.8-alpine, 7.4-alpine, 7-alpine, 7.4.8-alpine3.21, 7.4-alpine3.21, 7-alpine3.21, alpine, alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9d9b74b729d555ef784db63c1941b73d1c47a6f9
-Directory: 7.4/alpine
-
-Tags: 7.2.13, 7.2, 7.2.13-bookworm, 7.2-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9d9b74b729d555ef784db63c1941b73d1c47a6f9
-Directory: 7.2/debian
-
-Tags: 7.2.13-alpine, 7.2-alpine, 7.2.13-alpine3.21, 7.2-alpine3.21
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9d9b74b729d555ef784db63c1941b73d1c47a6f9
-Directory: 7.2/alpine
+GitCommit: 0e6db74e25f6b4e301b4e9a1fb3e72443a8ba4d7
+GitFetch: refs/tags/v7.4.8
+Directory: alpine
 
 Tags: 6.2.21, 6.2, 6, 6.2.21-bookworm, 6.2-bookworm, 6-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x


### PR DESCRIPTION
Automated update for Redis 7.4.8

Release commit: 0e6db74e25f6b4e301b4e9a1fb3e72443a8ba4d7
Release tag: v7.4.8
Compare: https://github.com/redislabsdev/docker-library-redis/compare/v7.4.8^1...v7.4.8

@adamiBs @yossigo @adobrzhansky @maxb-io @dagansandler @Peter-Sh