### PR TITLE
Redis: Update to 7.2.14

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -66,27 +66,15 @@ GitCommit: 7f2385183921bba168de2f0444cf455637c044e3
 GitFetch: refs/tags/v8.0.6
 Directory: alpine
 
-Tags: 7.4.9, 7.4, 7, 7.4.9-bookworm, 7.4-bookworm, 7-bookworm
+Tags: 7.2.14, 7.2, 7, 7.2.14-bookworm, 7.2-bookworm, 7-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: af0c2d7c264cdd38f55bd56a232ef9b94b64feb1
-GitFetch: refs/tags/v7.4.9
-Directory: debian
-
-Tags: 7.4.9-alpine, 7.4-alpine, 7-alpine, 7.4.9-alpine3.21, 7.4-alpine3.21, 7-alpine3.21
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: af0c2d7c264cdd38f55bd56a232ef9b94b64feb1
-GitFetch: refs/tags/v7.4.9
-Directory: alpine
-
-Tags: 7.2.14, 7.2, 7.2.14-bookworm, 7.2-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ed51d0c7b44b9de72d368adf33ead9736f762406
+GitCommit: 0a362f52c58445de1faf950919711fd1afab319a
 GitFetch: refs/tags/v7.2.14
 Directory: debian
 
-Tags: 7.2.14-alpine, 7.2-alpine, 7.2.14-alpine3.21, 7.2-alpine3.21
+Tags: 7.2.14-alpine, 7.2-alpine, 7-alpine, 7.2.14-alpine3.21, 7.2-alpine3.21, 7-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: ed51d0c7b44b9de72d368adf33ead9736f762406
+GitCommit: 0a362f52c58445de1faf950919711fd1afab319a
 GitFetch: refs/tags/v7.2.14
 Directory: alpine
 


### PR DESCRIPTION
Automated update for Redis 7.2.14

Release commit: 0a362f52c58445de1faf950919711fd1afab319a
Release tag: v7.2.14
Compare: https://github.com/redis/docker-library-redis/compare/v7.2.14^1...v7.2.14

@yossigo @dagansandler @Peter-Sh @AngelYanev @dariaguy @kalinstaykov @hilabarkai @gonen-red