### PR TITLE
Redis: Update to 8.8-rc1

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -8,16 +8,16 @@ Maintainers: Yossi Gottlieb <yossi@redis.com> (@yossigo),
              Gonen Goshen <gonen.goshen@redis.com> (@gonen-red)
 GitRepo: https://github.com/redis/docker-library-redis.git
 
-Tags: 8.8-m03, 8.8-m03-trixie
+Tags: 8.8-rc1, 8.8-rc1-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
-GitCommit: 47b5cf675aac356867239fae932a7871768ec020
-GitFetch: refs/tags/v8.8-m03
+GitCommit: 565cd595f6faf0b998e61f17035b837d9198c243
+GitFetch: refs/tags/v8.8-rc1
 Directory: debian
 
-Tags: 8.8-m03-alpine, 8.8-m03-alpine3.23
+Tags: 8.8-rc1-alpine, 8.8-rc1-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 47b5cf675aac356867239fae932a7871768ec020
-GitFetch: refs/tags/v8.8-m03
+GitCommit: 565cd595f6faf0b998e61f17035b837d9198c243
+GitFetch: refs/tags/v8.8-rc1
 Directory: alpine
 
 Tags: 8.6.3, 8.6, 8, 8.6.3-trixie, 8.6-trixie, 8-trixie, latest, trixie


### PR DESCRIPTION
Automated update for Redis 8.8-rc1

Release commit: 565cd595f6faf0b998e61f17035b837d9198c243
Release tag: v8.8-rc1
Compare: https://github.com/redis/docker-library-redis/compare/v8.8-rc1^1...v8.8-rc1

@yossigo @dagansandler @Peter-Sh @AngelYanev @dariaguy @kalinstaykov @hilabarkai @gonen-red