### PR TITLE
Redis: Update to 8.4.4

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -20,40 +20,40 @@ GitCommit: 40511fc518c300f3b48059daf43c7ac2ef97550b
 GitFetch: refs/tags/v8.8.0
 Directory: alpine
 
-Tags: 8.6.3, 8.6, 8.6.3-trixie, 8.6-trixie
+Tags: 8.6.4, 8.6, 8.6.4-trixie, 8.6-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
-GitCommit: 0e8b375a38d5b818b5baf23372e395ff8ee99d8e
-GitFetch: refs/tags/v8.6.3
+GitCommit: 0076c90a8028d29b25313f7272fa2d1245c3be76
+GitFetch: refs/tags/v8.6.4
 Directory: debian
 
-Tags: 8.6.3-alpine, 8.6-alpine, 8.6.3-alpine3.23, 8.6-alpine3.23
+Tags: 8.6.4-alpine, 8.6-alpine, 8.6.4-alpine3.23, 8.6-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0e8b375a38d5b818b5baf23372e395ff8ee99d8e
-GitFetch: refs/tags/v8.6.3
+GitCommit: 0076c90a8028d29b25313f7272fa2d1245c3be76
+GitFetch: refs/tags/v8.6.4
 Directory: alpine
 
-Tags: 8.4.3, 8.4, 8.4.3-trixie, 8.4-trixie
+Tags: 8.4.4, 8.4, 8.4.4-trixie, 8.4-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
-GitCommit: 5d4599c7c6c1a8cce4f7863f960315ba825e3020
-GitFetch: refs/tags/v8.4.3
+GitCommit: 75ad715d290fef57489d801696d4c75ceb97e1fe
+GitFetch: refs/tags/v8.4.4
 Directory: debian
 
-Tags: 8.4.3-alpine, 8.4-alpine, 8.4.3-alpine3.22, 8.4-alpine3.22
+Tags: 8.4.4-alpine, 8.4-alpine, 8.4.4-alpine3.22, 8.4-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5d4599c7c6c1a8cce4f7863f960315ba825e3020
-GitFetch: refs/tags/v8.4.3
+GitCommit: 75ad715d290fef57489d801696d4c75ceb97e1fe
+GitFetch: refs/tags/v8.4.4
 Directory: alpine
 
-Tags: 8.2.6, 8.2, 8.2.6-bookworm, 8.2-bookworm
+Tags: 8.2.7, 8.2, 8.2.7-bookworm, 8.2-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8f9c996974573b6031d867a49ec1d46e4e94e9e2
-GitFetch: refs/tags/v8.2.6
+GitCommit: 75cd859f27eb5b534583eac9f4c166a87160192a
+GitFetch: refs/tags/v8.2.7
 Directory: debian
 
-Tags: 8.2.6-alpine, 8.2-alpine, 8.2.6-alpine3.22, 8.2-alpine3.22
+Tags: 8.2.7-alpine, 8.2-alpine, 8.2.7-alpine3.22, 8.2-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 8f9c996974573b6031d867a49ec1d46e4e94e9e2
-GitFetch: refs/tags/v8.2.6
+GitCommit: 75cd859f27eb5b534583eac9f4c166a87160192a
+GitFetch: refs/tags/v8.2.7
 Directory: alpine
 
 Tags: 7.4.9, 7.4, 7, 7.4.9-bookworm, 7.4-bookworm, 7-bookworm


### PR DESCRIPTION
Automated update for Redis 8.4.4

Release commit: 75ad715d290fef57489d801696d4c75ceb97e1fe
Release tag: v8.4.4
Compare: https://github.com/redis/docker-library-redis/compare/v8.4.4^1...v8.4.4

@yossigo @dagansandler @Peter-Sh @AngelYanev @dariaguy @kalinstaykov @hilabarkai @gonen-red